### PR TITLE
Remove nunjucks as a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,8 @@
   "devDependencies": {
     "chai": "^1.9.2",
     "mocha": "^2.2.5",
-    "marked": "^0.3.3"
-  },
-  "dependencies": {
-    "nunjucks": "^1.1.0"
+    "marked": "^0.3.3",
+    "nunjucks": "^2.3.0"
   },
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "marked": "^0.3.3",
     "nunjucks": "^2.3.0"
   },
+  "peerDependencies": {
+    "nunjucks": "^2.3.0"
+  },
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
This addresses #13. I removed nunjucks as a direct dependency and added it as a dev dependency... I also upgrade the dev dependency to 2.3.0. Should I add a nunjucks as a peerDependency?