### PR TITLE
Updated install instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A nunjuck extension that adds a markdown tag. This plugin allows you to choose y
 ## Install
 
 ``` bash
-npm install marked --save
+npm install nunjucks-markdown --save
 ```
 
 ## Usage


### PR DESCRIPTION
The instructions on how to install `nunjucks-markdown` were previously prompting users to install `marked`.